### PR TITLE
Account for race conditions between site & action deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ jobs:
 On pull requests, the number will be extracted from the Github event data and used to generate the deploy preview URL as follows: `https://deploy-preview-$PR_NUMBER--$NETLIFY_SITE` and override the URL. The URL will be used as fallback on pushes event.
 
 
+### Race conditions
+
+If your site takes more than ~3 mins to deploy, then the lighthouse test will likely run before your site is online and will fail. You can pass the deploy time to the action using the `site_build_time` parameter:
+
+```
+jobs:
+  audit:
+    # ...
+    - uses: jakejarvis/lighthouse-action@master
+      with:
+        # ... Same as above
+        site_build_time: 300  # 5 mins in seconds 
+```
+
+The action will try to sleep for `site_build_time - action_build_time` if your site is longer than the average time it takes to build the action. This value is ignored if under 3 mins.
+
 ## To-Do
 
 - **Make CI fail if scores do not meet specified thresholds.**

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,18 @@ else
   REPORT_URL=${INPUT_URL}
 fi
 
+# Delay test if deployment takes longer than the action
+ACTION_BUILD_TIME=180  # 3 minutes in seconds
+
+if [ "${INPUT_SITE_BUILD_TIME:0}" -gt "${ACTION_BUILD_TIME}" ]
+then
+  # Site takes longer to deploy than the action to build:
+  # wait for the latest version to be online
+  WAIT_TIME_SECONDS=`expr ${INPUT_SITE_BUILD_TIME} - ${ACTION_BUILD_TIME}`
+  echo "Sleeping for ${WAIT_TIME_SECONDS} to wait for site to be up..."
+  sleep ${WAIT_TIME_SECONDS}
+fi
+
 lighthouse --port=9222 --chrome-flags="--headless --disable-gpu --no-sandbox --no-zygote" --output "html" --output "json" --output-path "report/lighthouse" ${REPORT_URL}
 
 # Parse individual scores from JSON output


### PR DESCRIPTION
Adding another option after deploying this to one of my site which takes ~5 mins to deploy the pull request preview.