### PR TITLE
Fix bug with `null` pull request number on branch push

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ mkdir report
 # In case of push event this might be empty
 PULL_REQUEST_NUMBER=$(jq .number ${GITHUB_EVENT_PATH})
 
-if [ -n "${INPUT_NETLIFY_SITE}" ] && [ -n "${PULL_REQUEST_NUMBER}" ]
+if [ -n "${INPUT_NETLIFY_SITE}" ] && [ -n "${PULL_REQUEST_NUMBER}" ] && [ "${PULL_REQUEST_NUMBER}" != "null" ]
 then
   # PR + Netlify enabled: generate Netlify deploy preview URL
   REPORT_URL="https://deploy-preview-${PULL_REQUEST_NUMBER}--${INPUT_NETLIFY_SITE}"


### PR DESCRIPTION
When running the action on branch pushes, `jq .number ${GITHUB_EVENT_PATH}` is actually returning `null` instead of an empty value. This evaluates to the string `"null"` in the bash variable, which in turns makes the condition of the if statement truthy.

If `INPUT_NETLIFY_SITE` is specified, the action fails: it's trying to evaluate a pull request preview for number PR `null`, which return a 404.