### PR TITLE
Install recommendations in base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -15,7 +15,7 @@ RUN apt-get update -qqy && \
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' && \
     apt-get update -qqy && \
-    apt-get install -qqy --no-install-recommends google-chrome-stable && \
+    apt-get install -qqy google-chrome-stable && \
     rm /etc/apt/sources.list.d/google-chrome.list && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 


### PR DESCRIPTION
Fixes #25 when I run from my computer

## Command

```
docker run --name lighthouse-action --workdir /github/workspace --rm -e OUTPUT_PATH=/github/workspace -e INPUT_URL=https://www.lewiscowles.co.uk -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE=/github/workspace -e GITHUB_ACTION -e GITHUB_EVENT_PATH=/dev/null -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v $(pwd):"/github/workspace" lighthouse-action
```

Obviously a lot I'm missing having just lifted this from the Github action namespace, and a little confused how `INPUT_URL` is mapped to `REPORT_URL` etc, but it worked to give me my 100 score :grin:

I also altered the built image to build from the base rather than pull from online (it's what this edit is about). That was the only change (and not one needed in patch) to be able to push to github.